### PR TITLE
Minor improvement at App.js

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -29,16 +29,15 @@ const palette = {
 };
 
 export class App extends React.Component {
-    render() {
-        const theme = createMuiTheme({ palette });
-
-        // Create an http link:
-        const httpLink = new HttpLink({
+    
+    componentWillMount() {
+     // Create an http link:
+        this.httpLink = new HttpLink({
             uri: 'http://localhost:8080/graphql'
         });
 
         // Create a WebSocket link:
-        const wsLink = new WebSocketLink({
+        this.wsLink = new WebSocketLink({
             uri: 'ws://localhost:8080/subscriptions',
             options: {
                 reconnect: true
@@ -47,7 +46,7 @@ export class App extends React.Component {
 
         // Using the ability to split links, send data to each link
         // depending on what kind of operation is being sent
-        const link = split(
+        this.link = split(
             // split based on operation type
             ({ query }) => {
                 const { kind, operation } = getMainDefinition(query);
@@ -61,13 +60,17 @@ export class App extends React.Component {
         );
 
         // Create the Apollo client
-        const apolloClient = new ApolloClient({
+        this.apolloClient = new ApolloClient({
             link: link,
             cache: new InMemoryCache()
-        });
-
+        });   
+    }
+    
+    render() {
+        const theme = createMuiTheme({ palette });
+       
         return (
-            <ApolloProvider client={apolloClient}>
+            <ApolloProvider client={this.apolloClient}>
                 <MuiThemeProvider theme={theme}>
                     <Provider>
                         <Router history={browserHistory}>

--- a/src/app.js
+++ b/src/app.js
@@ -55,13 +55,13 @@ export class App extends React.Component {
                     operation === 'subscription'
                 );
             },
-            wsLink,
-            httpLink
+            this.wsLink,
+            this.httpLink
         );
 
         // Create the Apollo client
         this.apolloClient = new ApolloClient({
-            link: link,
+            link: this.link,
             cache: new InMemoryCache()
         });   
     }


### PR DESCRIPTION
Hi, I've noticed you instantiate all of the ApolloClient stuff at the render method of the App Component.
I've moved it all up to level component instead doing it inside the render method because if at any stage of the app, this component gets updated and triggers a re-render, it will re instantiate all of the ApolloClient related stuff and maybe could cause a little pain.

The ideal instead of this minor improvement will be to generate a GraphQL service to handle all this stuff externally from you components and handle it via MobX so all your state changes will be made inside MobX and the state of the App and you keep the UI clean.